### PR TITLE
[WIP] Serialize as unit variant sequence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ serde = "1"
 [dev-dependencies]
 bitflags = "1"
 ron = "0.1"
+serde_derive = "1"

--- a/examples/ron.rs
+++ b/examples/ron.rs
@@ -3,6 +3,8 @@ extern crate bitflags;
 #[macro_use]
 extern crate bitflags_serial;
 extern crate ron;
+#[macro_use]
+extern crate serde_derive;
 
 bitflags_serial!{
     struct Bits: u8 {


### PR DESCRIPTION
This PR attempts to reduce the magic line count by introducing an `enum` and taking advantage of serde-derived serialization for it's variants.

WIP because it doesn't work atm:
>thread 'rustc' has overflowed its stack
fatal runtime error: stack overflow
error: Could not compile `bitflags-serial`.