### PR TITLE
Fix recent breakage with RON-specific serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,12 @@ macro_rules! bitflags_serial {
                 }
                 Ok($BitFlags { bits })
             }
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: $crate::_serde::de::Error,
+            {
+                self.visit_bytes(v.as_bytes())
+            }
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
             where
                 E: $crate::_serde::de::Error,


### PR DESCRIPTION
As I detailed in ron-rs/ron#152 there is a wierd edge case where RON appears to fail for bitflags-serial while other formats succeed. 

I've narrowed this down to the fact that at some point, it seems RON swapped to requiring visit_str implementations, and not using visit_bytes where available. This caused a call to the default serde::Visitor::visit_str, which failed. Implementing it here works.

I'm not sure if its a bug in RON or bitflags-serial, but the fix here works.